### PR TITLE
config file read only

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,12 +34,3 @@ func readConfig(filename string) (*Config, error) {
 
 	return c, nil
 }
-
-func writeConfig(filename string, config *Config) error {
-	data, err := yaml.Marshal(config)
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(filename, data, 0644)
-}

--- a/main.go
+++ b/main.go
@@ -13,15 +13,6 @@ import (
 	_ "github.com/lib/pq"
 )
 
-func generatePassword() (string, error) {
-	bytes := make([]byte, 16)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-
-	return hex.EncodeToString(bytes), nil
-}
-
 func connectDB(username, password, dbhost, dbname string) (*sql.DB, error) {
 	return connectDBWithRetry(username, password, dbhost, dbname, 2)
 }
@@ -60,7 +51,10 @@ func execSQL(db *sql.DB, query string) error {
 
 func main() {
 
-	config, err := readConfig("ochami.yaml")
+        if config_file == "" {
+		log.Fatal("OCHAMI_CONFIG is required")
+	}
+	config, err := readConfig(config_file)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -98,13 +92,6 @@ func main() {
 		}
 
 		for _, user := range database.Users {
-			if user.Password == "" {
-				user.Password, err = generatePassword()
-				if err != nil {
-					log.Fatal(err)
-				}
-			}
-
 			err = execSQL(db, fmt.Sprintf("CREATE USER \"%s\" WITH PASSWORD '%s';", user.Name, user.Password))
 			if err != nil {
 				log.Fatal(err)
@@ -115,10 +102,5 @@ func main() {
 				log.Fatal(err)
 			}
 		}
-	}
-
-	err = writeConfig("ochami.yaml", config)
-	if err != nil {
-		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Added reading OCHAMI_CONFIG from env, no longer generating passwords or writing config file
This will make it so that the config file with passwords needs to be provided to ochami-init externally